### PR TITLE
Updated version dependency for bignum package

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "mongoose"
   ],
   "dependencies": {
-    "bignum": "~0.6.1"
+    "bignum": "~0.9"
   },
   "peerDependencies": {
     "mongoose": ">= 3.5.0 < 4"


### PR DESCRIPTION
Just updated the version number for the bignum package. Tested and works with node version:
- 0.10.37
- 0.11.16
- 0.12.0
